### PR TITLE
Load credentials from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+REDIS_URL=your-redis-url
+REDIS_TOKEN=your-redis-token
+MASTER_PASSWORD=your-master-password
+ONE_TIME_PASSWORDS=comma,separated,passwords

--- a/public/redisClient.js
+++ b/public/redisClient.js
@@ -1,9 +1,9 @@
+require('dotenv').config();
 const { Redis } = require('@upstash/redis');
 
-// Replace the URL and token with your actual Upstash Redis credentials
 const redis = new Redis({
-  url: 'https://sacred-turkey-52125.upstash.io',
-  token: 'AcudAAIncDFhMmJhZDJhMTUwYTE0ZjQ5OTY5YWIwZjhkMTBkNzU2ZnAxNTIxMjU',
+  url: process.env.REDIS_URL,
+  token: process.env.REDIS_TOKEN,
 });
 
 async function getChatData(chatId) {

--- a/server.js
+++ b/server.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const express = require('express');
 const bodyParser = require('body-parser');
 const fs = require('fs');
@@ -9,23 +10,30 @@ const port = process.env.PORT || 3000;
 /*********************************************/
 /* 1) Master password + optional one-time    */
 /*********************************************/
-const MASTER_PASSWORD = "662023"; // never changes
+const MASTER_PASSWORD = process.env.MASTER_PASSWORD || '662023';
 
-let ONE_TIME_PASSWORDS = new Set([
-  "slitlamp286",
-  "fundus512",
-  "pinna304",
-  "slitlamp286",
-  "fundus512",
-  "retina728",
-  "cornea203",
-  "jobson892",
-  "otoscope414",
-  "earcare917",
-  "auricle345",
-  "skincheck112",
-  "dermatol559",
-]);
+let ONE_TIME_PASSWORDS;
+if (process.env.ONE_TIME_PASSWORDS) {
+  ONE_TIME_PASSWORDS = new Set(
+    process.env.ONE_TIME_PASSWORDS.split(',').map((p) => p.trim()).filter(Boolean)
+  );
+} else {
+  ONE_TIME_PASSWORDS = new Set([
+    'slitlamp286',
+    'fundus512',
+    'pinna304',
+    'slitlamp286',
+    'fundus512',
+    'retina728',
+    'cornea203',
+    'jobson892',
+    'otoscope414',
+    'earcare917',
+    'auricle345',
+    'skincheck112',
+    'dermatol559',
+  ]);
+}
 
 /*********************************************/
 /* 2) Standard Setup                         */


### PR DESCRIPTION
## Summary
- add `.env.example`
- load Redis credentials from environment variables
- make master password & one-time list configurable via environment variables

## Testing
- `node -c server.js`
- `node -c public/redisClient.js`


------
https://chatgpt.com/codex/tasks/task_e_6841febb7e90832fa8f839eb45972ae5