### PR TITLE
Fix typos in ear marquee lines

### DIFF
--- a/public/boxes.html
+++ b/public/boxes.html
@@ -129,19 +129,19 @@
 
         <!-- EAR lines, FIRST copy (IDs: earMarqueeLine1a, etc) -->
         <div class="box" id="earMarqueeLine1a">What is otitis media?</div>
-        <div class="box" id="earMarqueeLine2a">Can I see the tympanic menbrane with my Arclight?</div>
+        <div class="box" id="earMarqueeLine2a">Can I see the tympanic membrane with my Arclight?</div>
         <div class="box" id="earMarqueeLine3a">Lad 16, sore pinna, 2 day, itchy, hearing is good</div>
         <div class="box" id="earMarqueeLine4a">Tell me about syringing</div>
-        <div class="box" id="earMarqueeLine5a">Do I refer mastoditis urgently?</div>
+        <div class="box" id="earMarqueeLine5a">Do I refer mastoiditis urgently?</div>
         <div class="box" id="earMarqueeLine6a">Man 73yr, hearing poor. Poor view of canal. I just see wax</div>
         <div class="box" id="earMarqueeLine7a">Infant no response to voice. Been months</div>
 
         <!-- EAR lines, SECOND copy (IDs: earMarqueeLine1b, etc) -->
         <div class="box" id="earMarqueeLine1b">What is otitis media?</div>
-        <div class="box" id="earMarqueeLine2b">Can I see the tympanic menbrane with my Arclight?</div>
+        <div class="box" id="earMarqueeLine2b">Can I see the tympanic membrane with my Arclight?</div>
         <div class="box" id="earMarqueeLine3b">Lad 16, sore pinna, 2 day, itchy, hearing is good</div>
         <div class="box" id="earMarqueeLine4b">Tell me about syringing</div>
-        <div class="box" id="earMarqueeLine5b">Do I refer mastoditis urgently?</div>
+        <div class="box" id="earMarqueeLine5b">Do I refer mastoiditis urgently?</div>
         <div class="box" id="earMarqueeLine6b">Man 73yr, hearing poor. Poor view of canal. I just see wax</div>
         <div class="box" id="earMarqueeLine7b">Infant no response to voice. Been months</div>
       </div>

--- a/public/language.js
+++ b/public/language.js
@@ -75,10 +75,10 @@ export const translations = {
     eyeMarqueeLine7: 'Mother worried about baby as noticed white pupil, no vision in eye.',
 
     earMarqueeLine1: 'What is otitis media?',
-    earMarqueeLine2: 'Can I see the tympanic menbrane with my Arclight?',
+    earMarqueeLine2: 'Can I see the tympanic membrane with my Arclight?',
     earMarqueeLine3: 'Lad 16, sore pinna, 2 day, itchy, hearing is good',
     earMarqueeLine4: 'Tell me about syringing',
-    earMarqueeLine5: 'Do I refer mastoditis urgently?',
+    earMarqueeLine5: 'Do I refer mastoiditis urgently?',
     earMarqueeLine6: 'Man 73yr, hearing poor. Poor view of canal. I just see wax',
     earMarqueeLine7: 'Infant no response to voice. Been months',
 


### PR DESCRIPTION
## Summary
- correct 'tympanic membrane' and 'mastoiditis' in `boxes.html`
- update `earMarqueeLine2` and `earMarqueeLine5` in `language.js`

## Testing
- `npx prettier -v`

------
https://chatgpt.com/codex/tasks/task_e_682c86429930832fa3e4aa93e2ac3c6e