### PR TITLE
Remove Python references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # Alan Web Server
 
-This project provides a simple Express server with endpoints for recording and retrieving user information. A small Flask application in `public/app.py` is also included for basic password checks.
+This project provides a simple Express server with endpoints for recording and retrieving user information.
 
 ## Prerequisites
 
 - Node.js >=16 (tested with v22.16.0)
 - npm to install packages
-- Python >=3 if you want to run `public/app.py` or the helper script `public/create_hash.py`
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- drop mention of non-existent Flask app
- remove Python requirement in prerequisites

## Testing
- `npx jest --verbose` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6851808199b8832fab93e591eca5be00